### PR TITLE
Missing files from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="",
     packages=setuptools.find_packages(),
-    package_data={'p2fa': ['model/*/*']},
+    package_data={'p2fa': ['model/*', 'model/*/*']},
     scripts=['bin/p2fa'],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
After pip installing and running the following in python interpreter:
```
from p2fa.align import align

phonemes, words = align('wav_path', 'text_path')
```

I kept getting the following error: 
```
/tmp/p2fa/sound.wav -> /tmp/p2fa/tmp.plp 
  ERROR [+5010]  InitSource: Cannot open source file /usr/local/lib/python3.6/dist-packages/p2fa/model/hmmnames
  ERROR [+7010]  InitHMMSet: Can't open list file /usr/local/lib/python3.6/dist-packages/p2fa/model/hmmnames
  ERROR [+3228]  Initialise: MakeHMMSet failed
 FATAL ERROR - Terminating program HVite
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/dist-packages/p2fa/align.py", line 322, in align
    _alignments = read_aligned_mlf(output_mlf, sr, float(wave_start))
  File "/usr/local/lib/python3.6/dist-packages/p2fa/align.py", line 144, in read_aligned_mlf
    raise ValueError("Alignment did not complete succesfully.")
ValueError: Alignment did not complete succesfully.
```

From the error, some model files were missing when I tried to pip install the package from `setup.py`. After reinstalling, it was fixed.